### PR TITLE
Change localinstall path, only assume to know the git repo dir structure

### DIFF
--- a/scripts/install/install
+++ b/scripts/install/install
@@ -66,7 +66,7 @@ JDK=$(rpm -qa | grep openjdk | sort -n | tail -1)
 alternatives --install /usr/bin/java java /usr/lib/jvm/${JDK}/bin/java 0
 
 # Install third party packages
-yum -y localinstall ${HOME}/workspace/kojak/pkgs/*.rpm
+yum -y localinstall $(dirname $0)/../../pkgs/*.rpm
 
 echo -e "# 03. Creating Koji user directories" >> ${LOG}
 useradd koji


### PR DESCRIPTION
Right now when I have a base VM image or an OpenStack instance, I don't have a `${HOME}/workspace/` directory that my local `kojak` git clone lives in. This patch should handle the case allowing the git clone to live anywhere the end user likes (unless this file is being `source`'d somewhere I missed).

This patch looks for the rpms using relative pathing within the git repo.