### PR TITLE
Fixed incorrect variable declaration line 14

### DIFF
--- a/scripts/build/create-tag-base
+++ b/scripts/build/create-tag-base
@@ -11,7 +11,7 @@
 #set -x
 
 # Declare variables
-    WORKPSACE="$HOME/workspace"
+    WORKSPACE="$HOME/workspace"
     PROG="koji"
     PROD="${2}"
     ARCH="x86_64"


### PR DESCRIPTION
caught "WORKPSACE" typo causing /workspace directory creation failure.